### PR TITLE
Add Docker CI workflow for GHCR publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,69 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Log in to Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          # Set latest tag for default branch
+          type=ref,event=branch
+          type=ref,event=pr
+          # Git tag as Docker tag
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          # Latest tag for main branch
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Generate artifact attestation
+      if: github.event_name != 'pull_request'
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for smaller final image
-FROM python:3.12-slim as builder
+FROM python:3.12-slim AS builder
 
 # Install uv for fast dependency management
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -18,13 +18,11 @@ COPY src/ src/
 # Install dependencies and build the package
 RUN uv venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-# First install dependencies
-RUN uv pip install --no-cache-dir mcp[cli] httpx pydantic
-# Then install the package with metadata
+# Install the package with all its dependencies from pyproject.toml
 RUN uv pip install --no-cache-dir .
 
 # Production stage
-FROM python:3.12-slim as production
+FROM python:3.12-slim AS production
 
 # Copy the virtual environment from builder stage
 COPY --from=builder /opt/venv /opt/venv
@@ -51,5 +49,5 @@ CMD ["repology-mcp-server", "--transport", "stdio"]
 LABEL org.opencontainers.image.title="Repology MCP Server"
 LABEL org.opencontainers.image.description="Model Context Protocol server for Repology API"
 LABEL org.opencontainers.image.version="0.1.0"
-LABEL org.opencontainers.image.source="https://github.com/modelcontextprotocol/repology-mcp-server"
+LABEL org.opencontainers.image.source="https://github.com/tschoonj/repology-mcp-server"
 LABEL org.opencontainers.image.licenses="MIT"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Repology MCP Server
 
+[![CI](https://github.com/tschoonj/repology-mcp-server/workflows/CI/badge.svg)](https://github.com/tschoonj/repology-mcp-server/actions/workflows/ci.yml)
+[![Docker](https://github.com/tschoonj/repology-mcp-server/workflows/Docker/badge.svg)](https://github.com/tschoonj/repology-mcp-server/actions/workflows/docker.yml)
+[![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Ftschoonj%2Frepology--mcp--server-blue)](https://github.com/tschoonj/repology-mcp-server/pkgs/container/repology-mcp-server)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A Model Context Protocol (MCP) server that provides access to the [Repology](https://repology.org) package repository data through a standardized interface.
 
 ## Features
@@ -57,17 +62,42 @@ Add to your Claude Desktop configuration:
 }
 ```
 
-### With Docker for Claude Desktop
-
-If you prefer using Docker:
+Or using the pre-built Docker image:
 
 ```json
 {
   "mcpServers": {
     "repology": {
-      "command": "./docker-run.sh",
-      "args": ["stdio"],
-      "cwd": "/path/to/repology-mcp-server"
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/tschoonj/repology-mcp-server:latest"]
+    }
+  }
+}
+```
+
+### With VS Code
+
+Add to your VS Code settings (`.vscode/settings.json` or user settings):
+
+```json
+{
+  "mcp.servers": {
+    "repology": {
+      "command": "uv",
+      "args": ["run", "repology-mcp-server"]
+    }
+  }
+}
+```
+
+Or using the pre-built Docker image:
+
+```json
+{
+  "mcp.servers": {
+    "repology": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "ghcr.io/tschoonj/repology-mcp-server:latest"]
     }
   }
 }
@@ -82,22 +112,34 @@ uv run mcp dev src/repology_mcp/server.py
 
 ### Using Docker
 
-```bash
-# Build the Docker image
-./docker-run.sh build
+#### Pre-built images from GitHub Container Registry
 
-# Run with stdio transport (for MCP clients like Claude Desktop)
-./docker-run.sh stdio
+```bash
+# Pull the latest image
+docker pull ghcr.io/tschoonj/repology-mcp-server:latest
+
+# Run with stdio transport
+docker run -i --rm ghcr.io/tschoonj/repology-mcp-server:latest
 
 # Run with HTTP transport on port 8000
-./docker-run.sh http
+docker run --rm -p 8000:8000 ghcr.io/tschoonj/repology-mcp-server:latest --transport http --port 8000
 
-# Run with SSE transport on port 8001  
-./docker-run.sh sse
+# Use a specific version
+docker pull ghcr.io/tschoonj/repology-mcp-server:1.0.0
+docker run -i --rm ghcr.io/tschoonj/repology-mcp-server:1.0.0
+```
 
-# Using docker-compose
-docker-compose up repology-mcp-http    # HTTP transport
-docker-compose up repology-mcp-sse     # SSE transport (with profile)
+#### Local development with Docker
+
+```bash
+# Build the Docker image locally
+docker build -t repology-mcp-server .
+
+# Run with stdio transport
+docker run -i --rm repology-mcp-server
+
+# Run with HTTP transport on port 8000
+docker run --rm -p 8000:8000 repology-mcp-server --transport http --port 8000
 ```
 
 ## Development


### PR DESCRIPTION
This PR adds a comprehensive Docker CI/CD workflow that builds and publishes Docker images to GitHub Container Registry (GHCR).

## 🐳 **Docker Workflow Features**

### **Build Strategy**
- **Pull Requests**: Build Docker images to test compatibility (no push)
- **Main Branch**: Build and push with `latest` tag
- **Git Tags**: Build and push with semantic version tags (e.g., `v1.0.0` → `1.0.0`, `1.0`, `1`)

### **Multi-Platform Support**
- **linux/amd64**: Standard x86_64 architecture
- **linux/arm64**: ARM64 architecture (Apple Silicon, ARM servers)

### **Optimization & Security**
- **GitHub Actions Cache**: Faster builds using layer caching
- **Artifact Attestation**: Security provenance for published images
- **Non-root User**: Security-hardened container execution
- **Multi-stage Build**: Smaller production images

## 🔧 **Dockerfile Improvements**

### **Dependency Management**
- ✅ **Cleaned up**: Removed hardcoded dependencies 
- ✅ **pyproject.toml**: Now properly uses project dependencies
- ✅ **Single install**: `uv pip install .` pulls all deps automatically

### **Code Quality**
- ✅ **FROM casing**: Fixed `as` → `AS` for consistency
- ✅ **Labels**: Updated repository URL to correct location

## 🚀 **Usage**

### **Pull Images**
```bash
# Latest from main branch
docker pull ghcr.io/tschoonj/repology-mcp-server:latest

# Specific version
docker pull ghcr.io/tschoonj/repology-mcp-server:v1.0.0
```

### **Run Container**
```bash
# STDIO transport (default)
docker run ghcr.io/tschoonj/repology-mcp-server:latest

# HTTP transport
docker run -p 8000:8000 ghcr.io/tschoonj/repology-mcp-server:latest --transport http
```

This workflow ensures Docker images are properly tested in PRs and automatically published when code is merged or tagged, following container registry best practices.