### PR TITLE
Fix CI pipeline: remove Codecov integration and add attestation permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,6 @@ jobs:
       env:
         # Add rate limiting delay for integration tests
         REPOLOGY_RATE_LIMIT_DELAY: "1.0"
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-
   lint:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
       packages: write
       id-token: write  # Required for artifact attestation
+      attestations: write  # Required for creating attestations
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This PR fixes the CI pipeline issues:

## Changes Made

1. **Remove Codecov coverage upload**: Removed the `codecov/codecov-action@v5` step from the CI workflow to simplify the testing pipeline
2. **Add attestation permissions**: Added `attestations: write` permission to the Docker workflow to fix the post-merge CI failure

## Problem Solved

The recent merge to main caused a CI failure with the error "Resource not accessible by integration" when trying to create build attestations. This was because the `actions/attest-build-provenance` action requires both `id-token: write` and `attestations: write` permissions.

## Testing

- [ ] CI pipeline runs successfully
- [ ] Docker workflow creates attestations without errors
- [ ] All tests pass