### PR TITLE
Add TestPyPI publishing to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,37 @@ jobs:
       run: |
         uv run mypy src/ --ignore-missing-imports
       continue-on-error: true  # Don't fail CI on mypy errors initially
+
+  publish-test:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/repology-mcp-server/
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "latest"
+
+    - name: Build package
+      run: |
+        uv build
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true


### PR DESCRIPTION
This PR adds TestPyPI publishing functionality to the CI workflow to enable automated package publishing for testing before production releases.

## Changes Made

### 🚀 **TestPyPI Publishing Job**
- Added `publish-test` job that runs after both `test` and `lint` jobs pass
- Only triggers on pushes to the main branch (not on PRs)
- Uses GitHub's trusted publishing for secure authentication
- Publishes to TestPyPI for safe testing before production

### 🔧 **Environment Configuration**
- Configured `testpypi` environment with proper name and URL
- Set up `id-token: write` permission for trusted publishing
- Added TestPyPI repository URL: `https://test.pypi.org/legacy/`

### 📦 **Package Building**
- Uses `uv build` to create distribution packages
- Leverages the existing uv setup for consistency
- All GitHub Actions use latest versions

### 🔒 **Security & Best Practices**
- Uses trusted publishing (no API tokens needed)
- Proper job dependencies ensure tests pass before publishing
- Verbose output for debugging if needed

## Testing Strategy

This will safely test the publishing pipeline using TestPyPI before setting up production PyPI publishing. Once merged and the TestPyPI environment is configured in GitHub settings, pushes to main will automatically publish test versions.

## Next Steps

After merging:
1. Configure TestPyPI trusted publishing in GitHub repository settings
2. Test the publishing workflow with a main branch push
3. Create production PyPI publishing job if needed