### PR TITLE
Update CI workflow for production PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
 
@@ -73,14 +74,14 @@ jobs:
         uv run mypy src/ --ignore-missing-imports
       continue-on-error: true  # Don't fail CI on mypy errors initially
 
-  publish-test:
-    name: Publish to TestPyPI
+  publish:
+    name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: [test, lint]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/repology-mcp-server/
+      name: pypi
+      url: https://pypi.org/p/repology-mcp-server/
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
@@ -101,8 +102,7 @@ jobs:
       run: |
         uv build
 
-    - name: Publish to TestPyPI
+    - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
         verbose: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Repology MCP Server
 
-[![CI](https://github.com/tschoonj/repology-mcp-server/workflows/CI/badge.svg)](https://github.com/tschoonj/repology-mcp-server/actions/workflows/ci.yml)
-[![Docker](https://github.com/tschoonj/repology-mcp-server/workflows/Docker/badge.svg)](https://github.com/tschoonj/repology-mcp-server/actions/workflows/docker.yml)
+[![CI](https://github.com/tschoonj/repology-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/tschoonj/repology-mcp-server/actions/workflows/ci.yml)
+[![Docker](https://github.com/tschoonj/repology-mcp-server/actions/workflows/docker.yml/badge.svg)](https://github.com/tschoonj/repology-mcp-server/actions/workflows/docker.yml)
 [![Docker Image](https://img.shields.io/badge/docker-ghcr.io%2Ftschoonj%2Frepology--mcp--server-blue)](https://github.com/tschoonj/repology-mcp-server/pkgs/container/repology-mcp-server)
+[![PyPI](https://img.shields.io/pypi/v/repology-mcp-server)](https://pypi.org/project/repology-mcp-server/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Model Context Protocol (MCP) server that provides access to the [Repology](https://repology.org) package repository data through a standardized interface.


### PR DESCRIPTION
This PR updates the CI workflow to publish to production PyPI instead of TestPyPI, with the publishing triggered only on version tags.

## Changes Made

### 🚀 **Production PyPI Publishing**
- Updated environment from `testpypi` to `pypi`
- Changed environment URL to point to `https://pypi.org/p/repology-mcp-server/`
- Removed TestPyPI repository URL (now uses default PyPI)

### 🏷️ **Tag-Based Publishing**
- Updated trigger condition to run only on tags starting with 'v' (e.g., `v1.0.0`, `v2.1.3`)
- Added tag trigger pattern `v*` to workflow
- Changed from: `github.ref == 'refs/heads/main'`
- To: `startsWith(github.ref, 'refs/tags/v')`

### 🔧 **Configuration Updates**
- Renamed job from `publish-test` to `publish`
- Updated job display name to "Publish to PyPI"
- Updated step names to reflect production publishing
- Maintained trusted publishing with `id-token: write` permission

## Testing Strategy

The TestPyPI publishing was successfully tested and verified. This production setup follows the same pattern but:
- Uses the `pypi` environment (already configured in GitHub settings)
- Only triggers on version tags for controlled releases
- Publishes to the official PyPI registry

## Next Steps

After merging:
1. Create and push a version tag (e.g., `git tag v0.1.0 && git push origin v0.1.0`)
2. The CI will automatically build and publish to PyPI
3. Package will be available at https://pypi.org/p/repology-mcp-server/

## Security & Best Practices

✅ Uses GitHub's trusted publishing (no API tokens)  
✅ Only runs on explicit version tags  
✅ Requires tests and linting to pass first  
✅ Production environment configured with proper permissions